### PR TITLE
Add Support for New Option "tokenize_host_no_tld"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ ElasticSearch 8.4.1
 * `allow_malformed`: Defaults to `false`. If `true`, malformed URLs will not be rejected, but will be passed through without being tokenized.
 * `tokenize_malformed`: Defaults to `false`. Has no effect if `allow_malformed` is `false`. If both are `true`, an attempt will be made to tokenize malformed URLs using regular expressions.
 * `tokenize_host`: Defaults to `true`. If `true`, the host will be further tokenized using a [reverse path hierarchy tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-pathhierarchy-tokenizer.html) with the delimiter set to `.`.
+* `tokenize_host_no_tld`: Defaults to `false`. If `true`, and used in conjunction with `tokenize_host`,  the TLD of the tokenized host will be omitted.
 * `tokenize_path`: Defaults to `true`. If `true`, the path will be tokenized using a [path hierarchy tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-pathhierarchy-tokenizer.html) with the delimiter set to `/`.
 * `tokenize_query`: Defaults to `true`. If `true`, the query string will be split on `&`.
 
@@ -81,6 +82,7 @@ curl 'http://localhost:9200/index_name/_analyze?analyzer=url_host&pretty' -d 'ht
 If the desired part cannot be found, no value will be indexed for that field.
 * `passthrough`: Defaults to `false`. If `true`, `allow_malformed` is implied, and any non-url tokens will be passed through the filter.  Valid URLs will be tokenized according to the filter's other settings.
 * `tokenize_host`: Defaults to `true`. If `true`, the host will be further tokenized using a [reverse path hierarchy tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-pathhierarchy-tokenizer.html) with the delimiter set to `.`.
+* `tokenize_host_no_tld`: Defaults to `false`. If `true`, and used in conjunction with `tokenize_host`,  the TLD of the tokenized host will be omitted.
 * `tokenize_path`: Defaults to `true`. If `true`, the path will be tokenized using a [path hierarchy tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-pathhierarchy-tokenizer.html) with the delimiter set to `/`.
 * `tokenize_query`: Defaults to `true`. If `true`, the query string will be split on `&`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-analysis-url</artifactId>
-    <version>8.4.1.0</version>
+    <version>8.4.1.1</version>
     <packaging>jar</packaging>
     <description>Elasticsearch URL token filter plugin</description>
 

--- a/src/main/java/org/elasticsearch/index/analysis/URLTokenFilterFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/URLTokenFilterFactory.java
@@ -18,6 +18,7 @@ public class URLTokenFilterFactory extends AbstractTokenFilterFactory {
     private final List<URLPart> parts;
     private final boolean urlDecode;
     private boolean tokenizeHost;
+    private boolean tokenizeHostNoTLD;
     private boolean tokenizePath;
     private boolean tokenizeQuery;
     private final boolean allowMalformed;
@@ -34,6 +35,7 @@ public class URLTokenFilterFactory extends AbstractTokenFilterFactory {
 
         this.urlDecode = settings.getAsBoolean("url_decode", false);
         this.tokenizeHost = settings.getAsBoolean("tokenize_host", true);
+        this.tokenizeHostNoTLD = settings.getAsBoolean("tokenize_host_no_tld", false);
         this.tokenizePath = settings.getAsBoolean("tokenize_path", true);
         this.tokenizeQuery = settings.getAsBoolean("tokenize_query", true);
         this.allowMalformed = settings.getAsBoolean("allow_malformed", false);
@@ -48,6 +50,7 @@ public class URLTokenFilterFactory extends AbstractTokenFilterFactory {
                 .setParts(parts)
                 .setTokenizeMalformed(tokenizeMalformed)
                 .setTokenizeHost(tokenizeHost)
+                .setTokenizeHostNoTLD(tokenizeHostNoTLD)
                 .setTokenizePath(tokenizePath)
                 .setTokenizeQuery(tokenizeQuery);
     }

--- a/src/main/java/org/elasticsearch/index/analysis/URLTokenizerFactory.java
+++ b/src/main/java/org/elasticsearch/index/analysis/URLTokenizerFactory.java
@@ -17,6 +17,7 @@ public class URLTokenizerFactory extends AbstractTokenizerFactory {
     private List<URLPart> parts;
     private boolean urlDecode;
     private boolean tokenizeHost;
+    private boolean tokenizeHostNoTLD;
     private boolean tokenizePath;
     private boolean tokenizeQuery;
     private boolean allowMalformed;
@@ -33,6 +34,7 @@ public class URLTokenizerFactory extends AbstractTokenizerFactory {
         }
         this.urlDecode = settings.getAsBoolean("url_decode", false);
         this.tokenizeHost = settings.getAsBoolean("tokenize_host", true);
+        this.tokenizeHostNoTLD = settings.getAsBoolean("tokenize_host_no_tld", false);
         this.tokenizePath = settings.getAsBoolean("tokenize_path", true);
         this.tokenizeQuery = settings.getAsBoolean("tokenize_query", true);
         this.allowMalformed = settings.getAsBoolean("allow_malformed", false);
@@ -46,6 +48,7 @@ public class URLTokenizerFactory extends AbstractTokenizerFactory {
         tokenizer.setParts(parts);
         tokenizer.setUrlDecode(urlDecode);
         tokenizer.setTokenizeHost(tokenizeHost);
+        tokenizer.setTokenizeHostNoTLD(tokenizeHostNoTLD);
         tokenizer.setTokenizePath(tokenizePath);
         tokenizer.setTokenizeQuery(tokenizeQuery);
         tokenizer.setAllowMalformed(allowMalformed);

--- a/src/main/java/org/elasticsearch/index/analysis/url/URLTokenFilter.java
+++ b/src/main/java/org/elasticsearch/index/analysis/url/URLTokenFilter.java
@@ -37,6 +37,11 @@ public final class URLTokenFilter extends TokenFilter {
     private boolean tokenizeHost = true;
 
     /**
+     * If true and used in conjunction with {@link URLTokenFilter#tokenizeHost}, the TLD of the tokenized host will be omitted.
+     */
+    private boolean tokenizeHostNoTLD = false;
+
+    /**
      * If true, the url's path will be tokenized using a {@link PathHierarchyTokenizer}
      */
     private boolean tokenizePath = true;
@@ -91,6 +96,11 @@ public final class URLTokenFilter extends TokenFilter {
 
     public URLTokenFilter setTokenizeHost(boolean tokenizeHost) {
         this.tokenizeHost = tokenizeHost;
+        return this;
+    }
+
+    public URLTokenFilter setTokenizeHostNoTLD(boolean tokenizeHostNoTLD) {
+        this.tokenizeHostNoTLD = tokenizeHostNoTLD;
         return this;
     }
 
@@ -180,6 +190,7 @@ public final class URLTokenFilter extends TokenFilter {
         tokenizer.setParts(new ArrayList<>(parts));
         tokenizer.setUrlDecode(urlDeocde);
         tokenizer.setTokenizeHost(tokenizeHost);
+        tokenizer.setTokenizeHostNoTLD(tokenizeHostNoTLD);
         tokenizer.setTokenizePath(tokenizePath);
         tokenizer.setTokenizeQuery(tokenizeQuery);
         tokenizer.setAllowMalformed(allowMalformed || passthrough);

--- a/src/main/java/org/elasticsearch/index/analysis/url/URLTokenizer.java
+++ b/src/main/java/org/elasticsearch/index/analysis/url/URLTokenizer.java
@@ -48,6 +48,11 @@ public final class URLTokenizer extends Tokenizer {
     private boolean tokenizeHost = true;
 
     /**
+     * If true and used in conjunction with {@link URLTokenizer#tokenizeHost}, the TLD of the tokenized host will be omitted.
+     */
+    private boolean tokenizeHostNoTLD = false;
+
+    /**
      * If true, the url's path will be tokenized using a {@link PathHierarchyTokenizer}
      */
     private boolean tokenizePath = true;
@@ -106,6 +111,8 @@ public final class URLTokenizer extends Tokenizer {
     public void setUrlDecode(boolean urlDecode) { this.urlDecode = urlDecode; }
 
     public void setTokenizeHost(boolean tokenizeHost) { this.tokenizeHost = tokenizeHost; }
+
+    public void setTokenizeHostNoTLD(boolean tokenizeHostNoTLD) { this.tokenizeHostNoTLD = tokenizeHostNoTLD; }
 
     public void setTokenizePath(boolean tokenizePath) { this.tokenizePath = tokenizePath; }
 
@@ -356,7 +363,11 @@ public final class URLTokenizer extends Tokenizer {
             int end = getEndIndex(start, partStringRaw);
             return Collections.singletonList(new Token(partString, URLPart.HOST, start, end));
         }
-        return tokenize(URLPart.HOST, addReader(new ReversePathHierarchyTokenizer('.', '.'), new StringReader(partString)), start);
+        List<Token> hostTokens = tokenize(URLPart.HOST, addReader(new ReversePathHierarchyTokenizer('.', '.'), new StringReader(partString)), start);
+        if (tokenizeHostNoTLD && !hostTokens.isEmpty()) {
+            hostTokens.remove(hostTokens.size() - 1);
+        }
+        return hostTokens;
     }
 
 

--- a/src/test/java/org/elasticsearch/index/analysis/url/URLTokenFilterTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/url/URLTokenFilterTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 
 import static org.elasticsearch.index.analysis.url.IsTokenStreamWithTokenAndPosition.hasTokenAtOffset;
+import static org.hamcrest.CoreMatchers.not;
 
 public class URLTokenFilterTest extends BaseTokenStreamTestCase {
     public static final String TEST_HTTP_URL = "http://www.foo.bar.com:9200/index_name/type_name/_search.html?foo=bar&baz=bat#tag";
@@ -42,6 +43,28 @@ public class URLTokenFilterTest extends BaseTokenStreamTestCase {
         filter = createFilter(TEST_HTTP_URL, URLPart.HOST)
                 .setUrlDeocde(false);
         assertThat(filter, hasTokenAtOffset("com", 19, 22));
+    }
+
+    @Test
+    public void testFilterHostNoTLD() throws IOException {
+        assertTokenStreamContents(createFilter(TEST_HTTP_URL, URLPart.HOST).setTokenizeHost(false).setTokenizeHostNoTLD(true), "www.foo.bar.com");
+
+        URLTokenFilter filter = createFilter(TEST_HTTP_URL, URLPart.HOST)
+                .setUrlDeocde(false)
+                .setTokenizeHostNoTLD(true);
+        assertThat(filter, hasTokenAtOffset("www.foo.bar.com", 7, 22));
+        filter = createFilter(TEST_HTTP_URL, URLPart.HOST)
+                .setUrlDeocde(false)
+                .setTokenizeHostNoTLD(true);
+        assertThat(filter, hasTokenAtOffset("foo.bar.com", 11, 22));
+        filter = createFilter(TEST_HTTP_URL, URLPart.HOST)
+                .setUrlDeocde(false)
+                .setTokenizeHostNoTLD(true);
+        assertThat(filter, hasTokenAtOffset("bar.com", 15, 22));
+        filter = createFilter(TEST_HTTP_URL, URLPart.HOST)
+                .setUrlDeocde(false)
+                .setTokenizeHostNoTLD(true);
+        assertThat(filter, not(hasTokenAtOffset("com", 19, 22)));
     }
 
     @Test

--- a/src/test/java/org/elasticsearch/index/analysis/url/URLTokenizerIntegrationTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/url/URLTokenizerIntegrationTest.java
@@ -35,6 +35,7 @@ public class URLTokenizerIntegrationTest extends URLAnalysisTestCase {
         assertTokensContain(URLTokenizerTest.TEST_HTTPS_URL, "tokenizer_url_protocol", "https");
 
         assertTokensContain(URLTokenizerTest.TEST_HTTP_URL, "tokenizer_url_host", "www.foo.bar.com", "foo.bar.com", "bar.com", "com");
+        assertTokensContain(URLTokenizerTest.TEST_HTTP_URL, "tokenizer_url_host_no_tld", "www.foo.bar.com", "foo.bar.com", "bar.com");
         List<AnalyzeAction.AnalyzeToken> hostTokens = assertTokensContain(URLTokenizerTest.TEST_HTTP_URL, "tokenizer_url_host_single", "www.foo.bar.com");
         assertThat(hostTokens, hasSize(1));
 
@@ -82,7 +83,6 @@ public class URLTokenizerIntegrationTest extends URLAnalysisTestCase {
         Text fragment = fragments[0];
         assertThat("URL was highlighted correctly", fragment.string(), equalTo("http://<b>www.foo.bar.com</b>:<b>8080</b>/baz/bat?bob=blah"));
     }
-
 
     @Test
     public void testBulkIndexing() throws Exception {

--- a/src/test/java/org/elasticsearch/index/analysis/url/URLTokenizerTest.java
+++ b/src/test/java/org/elasticsearch/index/analysis/url/URLTokenizerTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static org.elasticsearch.index.analysis.url.IsTokenStreamWithTokenAndPosition.hasTokenAtOffset;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 
 /**
@@ -51,6 +52,28 @@ public class URLTokenizerTest extends BaseTokenStreamTestCase {
         assertThat(tokenizer, hasTokenAtOffset("bar.com", 15, 22));
         tokenizer = createTokenizer(TEST_HTTP_URL, URLPart.HOST);
         assertThat(tokenizer, hasTokenAtOffset("com", 19, 22));
+    }
+
+    public void testTokenizeHostNoTLD() throws IOException {
+        URLTokenizer tokenizer = createTokenizer(TEST_HTTP_URL, URLPart.HOST);
+        tokenizer.setTokenizeHostNoTLD(true);
+        assertTokenStreamContents(tokenizer, stringArray("www.foo.bar.com", "foo.bar.com", "bar.com"));
+
+        tokenizer = createTokenizer(TEST_HTTP_URL, URLPart.HOST);
+        tokenizer.setTokenizeHostNoTLD(true);
+        assertThat(tokenizer, hasTokenAtOffset("www.foo.bar.com", 7, 22));
+
+        tokenizer = createTokenizer(TEST_HTTP_URL, URLPart.HOST);
+        tokenizer.setTokenizeHostNoTLD(true);
+        assertThat(tokenizer, hasTokenAtOffset("foo.bar.com", 11, 22));
+
+        tokenizer = createTokenizer(TEST_HTTP_URL, URLPart.HOST);
+        tokenizer.setTokenizeHostNoTLD(true);
+        assertThat(tokenizer, hasTokenAtOffset("bar.com", 15, 22));
+
+        tokenizer = createTokenizer(TEST_HTTP_URL, URLPart.HOST);
+        tokenizer.setTokenizeHostNoTLD(true);
+        assertThat(tokenizer, not(hasTokenAtOffset("com", 19, 22)));
     }
 
 

--- a/src/test/resources/test-settings.json
+++ b/src/test/resources/test-settings.json
@@ -46,6 +46,12 @@
                 "part": "host",
                 "tokenize_host": false
             },
+            "url_host_no_tld": {
+                "type": "url",
+                "part": "host",
+                "tokenize_host": true,
+                "tokenize_host_no_tld": true
+            },
             "url_port": {
                 "type": "url",
                 "part": "port"
@@ -85,6 +91,12 @@
             "url_host": {
                 "filter": [
                     "url_host"
+                ],
+                "tokenizer": "whitespace"
+            },
+            "url_host_no_tld": {
+                "filter": [
+                    "url_host_no_tld"
                 ],
                 "tokenizer": "whitespace"
             },


### PR DESCRIPTION
This new option defaults to `false`, but when set to `true` and used in conjunction with `tokenize_host` the TLD of the tokenized host will be omitted.

For example, the default behavior of `tokenize_host` produces the following:
```
foo.bar.com => [foo.bar.com, bar.com, com]
```

With `tokenize_host_no_tld` enabled:
```
foo.bar.com => [foo.bar.com, bar.com]
```